### PR TITLE
Add webhooks/events/documentation endpoint

### DIFF
--- a/lib/simple_spark/endpoints/webhooks.rb
+++ b/lib/simple_spark/endpoints/webhooks.rb
@@ -66,6 +66,14 @@ module SimpleSpark
         @client.call(method: :get, path: 'webhooks/events/samples', query_values: query_params)
       end
 
+      # Returns Returns a list of descriptions of the events, event types, and event fields that
+      # could be included in a webhooks batches
+      # @return [Array] a list of sample event hash objects
+      # @note See: https://developers.sparkpost.com/api/webhooks/#webhooks-get-events-documentation
+      def documentation
+        @client.call(method: :get, path: 'webhooks/events/documentation', query_values: {})
+      end
+
       # Delete a webhook
       # @param id [String] the ID
       # @note See: https://developers.sparkpost.com/api/#/reference/webhooks/update-and-delete


### PR DESCRIPTION
## What

Introduces the webhooks/events/documentation endpoint.
It list all the possible events that could be ingested via webhook.

## The events
```rb
3.2.1 :001 > require 'simple_spark'
 => true
3.2.1 :002 > subaccount_spark = SimpleSpark::Client.new(subaccount_id: 1)
3.2.1 :003 > subaccount_spark.webhooks.documentation

{"message_event"=>
  {"events"=>
    {"bounce"=>
      {"event"=>
        {"amp_enabled"=>{"description"=>"Indicates whether or not amp format was enabled", "sampleValue"=>true},
         "bounce_class"=>
          {"description"=>
            "Classification code for a given message (see [Bounce Classification Codes](https://support.sparkpost.com/customer/portal/articles/1929896))",
           "sampleValue"=>"1"},
         "campaign_id"=>{"description"=>"Campaign of which this message was a part", "sampleValue"=>"Example Campaign Name"},
         "click_tracking"=>{"description"=>"Indicates whether or not click tracking was enabled", "sampleValue"=>true},
         "customer_id"=>{"description"=>"SparkPost-customer identifier through which this message was sent", "sampleValue"=>"1"},
         "delv_method"=>{"description"=>"Protocol by which SparkPost delivered this message", "sampleValue"=>"esmtp"},

...

     "error"=>
      {"event"=>
        {"event_id"=>{"description"=>"Unique event identifier", "sampleValue"=>"0e5cf1fc-cb36-4c39-b695-3651b6ea6563"},
         "batch_id"=>{"description"=>"Universally unique identifier", "sampleValue"=>"96500f4d-d4f4-4f1b-8080-02f4682184bb"},
         "timestamp"=>
          {"description"=>"Event date and time, in Unix timestamp format (integer seconds since 00:00:00 GMT 1970-01-01)",
           "sampleValue"=>"1460989507"},
         "expiration_timestamp"=>
          {"description"=>"The time at which an ingest batch is no longer retrievable", "sampleValue"=>"2019-06-16T19:02:09.373Z"},
         "type"=>{"description"=>"Type of event this record describes", "sampleValue"=>"error"},
         "error_type"=>{"description"=>"Category of error that was encountered in processing", "sampleValue"=>"validation"},
         "customer_id"=>{"description"=>"SparkPost-customer identifier through which this message was sent", "sampleValue"=>"1"},
         "subaccount_id"=>{"description"=>"Unique subaccount identifier.", "sampleValue"=>"101"},
         "number_succeeded"=>{"description"=>"How many events succeeded processing", "sampleValue"=>500},
         "number_duplicates"=>{"description"=>"How many events were already processed in a previous batch", "sampleValue"=>350},
         "number_failed"=>{"description"=>"How many events failed processing", "sampleValue"=>50},
         "retryable"=>{"description"=>"Indicates if an error retryable", "sampleValue"=>false},
         "href"=>
          {"description"=>"A reference to a failed batch",
           "sampleValue"=>"https://api.sparkpost.com/api/v1/ingest/events/failures/fbd59e4c-1629-4736-803d-201ff9fa8dd6"}},
       "description"=>"Details of an Ingest API processing error",
       "display_name"=>"Ingest Event Error"}},
   "description"=>"Ingest events describe the processing status of an upload to /api/v1/ingest/events",
   "display_name"=>"Ingest Events"}}
```

Github wouldn't let me put all the events in the PR description because it's too long.
So [here it is here](https://gist.github.com/jonowar/baacbc46cb35c350a75b9d9fc564024b)

### Boiled down a little bit

```txt
3.2.1 :054 > res.each do |event_group_key, event_group_details|
3.2.1 :055 >   puts "=== #{event_group_key}: #{event_group_details['description']}"
3.2.1 :056 >   event_group_details['events'].each do |event_name, event_details|
3.2.1 :057 >     puts "= #{event_name}: #{event_details['description']}"
3.2.1 :058 >   end
3.2.1 :059 >   puts
3.2.1 :060 > end

=== message_event: Message events describe the life cycle of a message including injection, delivery, and disposition.
bounce: Remote MTA has permanently rejected a message.
delivery: Remote MTA acknowledged receipt of a message.
injection: Message is received by or injected into SparkPost.
sms_status: SMPP/SMS message produced a status log output
spam_complaint: Message was classified as spam by the recipient.
out_of_band: Remote MTA initially reported acceptance of a message, but it has since asynchronously reported that the message was not delivered.
policy_rejection: Due to policy, SparkPost rejected a message or failed to generate a message.
delay: Remote MTA has temporarily rejected a message.

=== track_event: Engagement events describe the behavior of a recipient with respect to the message sent.
click: Recipient clicked a tracked link in a message, thus prompting a redirect through the SparkPost click-tracking server to the link's destination.
open: Recipient opened a message in a mail client, thus rendering a tracking pixel at the bottom of the message.
initial_open: Recipient opened a message in a mail client, thus rendering a tracking pixel at the top of the message.
amp_click: Recipient clicked a tracked link in an AMP message, thus prompting a redirect through the SparkPost click-tracking server to the link's destination.
amp_open: Recipient opened an AMP message in a mail client, thus rendering a tracking pixel at the bottom of the message.
amp_initial_open: Recipient opened an AMP message in a mail client, thus rendering a tracking pixel at the top of the message.

=== gen_event: Generation events provide insight into message generation failures or rejections.
generation_failure: Message generation failed for an intended recipient.
generation_rejection: SparkPost rejected message generation due to policy.

=== unsubscribe_event: Unsubscribe events provide insight into the action the user performed to become unsubscribed.
list_unsubscribe: User clicked the 'unsubscribe' button on an email client.
link_unsubscribe: User clicked a hyperlink in a received email.

=== relay_event: Relay events describe the life cycle of an inbound message including injection, delivery, and disposition.
relay_injection: Relayed message is received by or injected into SparkPost.
relay_rejection: SparkPost rejected a relayed message or failed to generate a relayed message.
relay_delivery: Remote HTTP Endpoint acknowledged receipt of a relayed message.
relay_tempfail: Remote HTTP Endpoint has failed to accept a relayed message.
relay_permfail: Relayed message has reached the maximum retry threshold and will be removed from the system.

=== ab_test_event: A/B test events describe the conclusion of an A/B test, such as completion or cancellation
ab_test_completed: Results of an A/B test
ab_test_cancelled: Details of a canceled A/B test

=== ingest_event: Ingest events describe the processing status of an upload to /api/v1/ingest/events
success: Details of an Ingest API processing success
error: Details of an Ingest API processing error
```