### PR TITLE
Add recipient-validation endpoint

### DIFF
--- a/lib/simple_spark.rb
+++ b/lib/simple_spark.rb
@@ -12,7 +12,7 @@ require 'simple_spark/endpoints/message_events'
 require 'simple_spark/endpoints/events'
 require 'simple_spark/endpoints/webhooks'
 require 'simple_spark/endpoints/recipient_lists'
+require 'simple_spark/endpoints/recipient_validation'
 require 'simple_spark/endpoints/relay_webhooks'
 require 'simple_spark/endpoints/subaccounts'
 require 'simple_spark/endpoints/suppression_list'
-

--- a/lib/simple_spark/client.rb
+++ b/lib/simple_spark/client.rb
@@ -159,5 +159,9 @@ module SimpleSpark
     def recipient_lists
       Endpoints::RecipientLists.new(self)
     end
+
+    def recipient_validation
+      Endpoints::RecipientValidation.new(self)
+    end
   end
 end

--- a/lib/simple_spark/endpoints/recipient_validation.rb
+++ b/lib/simple_spark/endpoints/recipient_validation.rb
@@ -1,0 +1,47 @@
+module SimpleSpark
+  module Endpoints
+    # Provides access to the /recipient-validation endpoint
+    # @note Example validation responses
+    #
+    # a valid email:
+    # {
+    #   "results": {
+    #     "result": "valid",
+    #     "valid": true,
+    #     "is_role": false,
+    #     "is_disposable": false,
+    #     "delivery_confidence": 85
+    #     "is_free": true
+    #   }
+    # }
+    #
+    # an invalid email:
+    # {
+    #   "results": {
+    #     "valid": false,
+    #     "result": "undeliverable",
+    #     "reason": "Invalid Domain",
+    #     "is_role": false,
+    #     "is_disposable": false,
+    #     "delivery_confidence": 0
+    #     "is_free": false
+    #   }
+    # }
+    # @note See: https://developers.sparkpost.com/api/recipient-validation/#header-validation-object
+    class RecipientValidation
+      attr_accessor :client
+
+      def initialize(client)
+        @client = client
+      end
+
+      # Validate a single email
+      # @param email_address [String] The email address to validate
+      # @return [Hash] a Validation object
+      # @note See: https://developers.sparkpost.com/api/recipient-validation/#recipient-validation-get-email-address-validation
+      def validate(email_address)
+        @client.call(method: :get, path: "recipient-validation/single/#{email_address}")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

Introduces the recipient-validation/single endpoint.

This can be used to validate a single email and see how likely it is that an email sent to it would result in a success.

## The endpoint
```rb
3.2.1 :001 > require 'simple_spark'
3.2.1 :002 > simple_spark = SimpleSpark::Client.new
3.2.1 :003 > simple_spark.recipient_validation.validate('jono@numero.ai')
/Users/jono/code/simple_spark/lib/simple_spark/exceptions.rb:24:in `fail_with_exception_for_status': Forbidden. 403 (Error Code: ) (SimpleSpark::Exceptions::UnprocessableEntity)
```

## Notes

Currently getting a 403 error on it. I wonder if maybe we need to upgrade our account.