### PR TITLE
Add metrics/deliverability/mailbox-provider endpoint

### DIFF
--- a/lib/simple_spark/endpoints/metrics.rb
+++ b/lib/simple_spark/endpoints/metrics.rb
@@ -88,6 +88,18 @@ module SimpleSpark
         @client.call(method: :get, path: 'metrics/deliverability/template', query_values: values)
       end
 
+      # Deliverability Metrics By Mailbox Provider
+      # @param values [Hash] the values to query with
+      # @note dates from and need to be sent using strftime('%Y-%m-%dT%H:%M'), for convenience if provided as Time, Date or DateTime objects they will be automatically converted
+      # @return [Array] containg Metrics results i.e. { "count_accepted": 66, "mailbox_provider": "Gmail" }
+      # @note Example:
+      #   client.metrics.deliverability_metrics_by_mailbox_provider(from: '2013-04-20T07:12', to: '2018-04-20T07:12', metrics: 'count_accepted', timezone: 'America/New_York', subaccounts: 'acc123')
+      # @note See: https://developers.sparkpost.com/api/metrics/#metrics-get-metrics-by-mailbox-provider
+      def deliverability_metrics_by_mailbox_provider(values)
+        format_date_time_values(values)
+        @client.call(method: :get, path: 'metrics/deliverability/mailbox-provider', query_values: values)
+      end
+
       # Time Series
       # @param values [Hash] the values to query with
       # @note dates from and need to be sent using strftime('%Y-%m-%dT%H:%M'), for convenience if provided as Time, Date or DateTime objects they will be automatically converted


### PR DESCRIPTION
## What

Introduces the metrics/deliverability/mailbox-provider endpoint.

This can be used to receive deliverability metrics broken out by mailbox provider.

## The endpoint
```rb
3.2.1 :001 > require 'simple_spark'
3.2.1 :002 > simple_spark = SimpleSpark::Client.new
3.2.1 :003 > simple_spark.metrics.deliverability_metrics_by_mailbox_provider(from: "2023-08-14T18:30:34Z", metrics: 'count_injected
,count_sent,count_delivered,count_nonprefetched_unique_confirmed_opened,count_unique_clicked,count_unsubscribe,count_spam_complaint,count_b
ounce,count_rejected', campaigns: "broadcast_id:7")
 =>
[{"count_injected"=>1,
  "count_bounce"=>0,
  "count_rejected"=>0,
  "count_delivered"=>1,
  "count_sent"=>1,
  "count_spam_complaint"=>0,
  "count_unsubscribe"=>0,
  "count_unique_clicked"=>0,
  "count_nonprefetched_unique_confirmed_opened"=>1,
  "mailbox_provider"=>"Gsuite"}]
```