### PR TITLE
Add searching events with pagination

### DIFF
--- a/lib/simple_spark/endpoints/events.rb
+++ b/lib/simple_spark/endpoints/events.rb
@@ -26,6 +26,14 @@ module SimpleSpark
       def search(params = {})
         @client.call(method: :get, path: 'events/message', query_values: params)
       end
+
+      # Perform a filtered search for message event data. The response is sorted by descending timestamp.
+      # @param params [String] Params to use in the search
+      # @return [Array] a list of Event hash objects
+      # @note https://developers.sparkpost.com/api/events/#events-get-search-for-message-events
+      def search_for_pagination(params = {})
+        @client.call(method: :get, path: 'events/message', query_values: params, extract_results: false)
+      end
     end
   end
 end

--- a/lib/simple_spark/endpoints/events.rb
+++ b/lib/simple_spark/endpoints/events.rb
@@ -27,12 +27,21 @@ module SimpleSpark
         @client.call(method: :get, path: 'events/message', query_values: params)
       end
 
-      # Perform a filtered search for message event data. The response is sorted by descending timestamp.
+      # Perform a filtered search for message event data.
+      # The result is not extracted, and the next cursor is parsed for the next api call.
       # @param params [String] Params to use in the search
       # @return [Array] a list of Event hash objects
       # @note https://developers.sparkpost.com/api/events/#events-get-search-for-message-events
-      def search_for_pagination(params = {})
-        @client.call(method: :get, path: 'events/message', query_values: params, extract_results: false)
+      def search_with_pagination(params = {})
+        result = @client.call(method: :get, path: 'events/message', query_values: params, extract_results: false)
+
+        # append cursor, to be passed into the next query
+        next_url = result.dig('links', 'next')
+        if next_url != nil
+          result['cursor'] = CGI.parse(URI(next_url).query)['cursor'].first
+        end
+
+        result
       end
     end
   end

--- a/lib/simple_spark/endpoints/events.rb
+++ b/lib/simple_spark/endpoints/events.rb
@@ -33,6 +33,8 @@ module SimpleSpark
       # @return [Array] a list of Event hash objects
       # @note https://developers.sparkpost.com/api/events/#events-get-search-for-message-events
       def search_with_pagination(params = {})
+        params[:cursor] = 'initial' unless params[:cursor]
+
         result = @client.call(method: :get, path: 'events/message', query_values: params, extract_results: false)
 
         # append cursor, to be passed into the next query


### PR DESCRIPTION
Getting events with pagination.

Usage:
```rb
events = []
cursor = nil

subaccount_client = SimpleSpark::Client.new(subaccount_id: 17, debug: false)

loop do
  response = subaccount_client.events.search_with_pagination(campaigns: 'broadcast_id:30', from: 10.days.ago.iso8601, to: Time.now.iso8601, per_page: 1000, cursor:); nil
  events.concat(response['results'])
  cursor = response['cursor']
  break if cursor == nil
end

events.count
 => 3046
```