### PR TITLE
Allow Excon 1.x

### DIFF
--- a/simple_spark.gemspec
+++ b/simple_spark.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
 
 
   spec.add_dependency 'json', '>= 1.7.7', '< 3.0'
-  spec.add_dependency 'excon', '>= 0.16.0', '< 1.0'
+  spec.add_dependency 'excon', '>= 0.16.0', '< 2.0'
 end


### PR DESCRIPTION
## Summary

- relax the Excon runtime dependency ceiling from `< 1.0` to `< 2.0`
- allow consumers to resolve Excon 1.5 while retaining compatibility with existing Excon 0.x installations

## Why

The Numero `simple_spark` fork currently blocks Excon 1.x solely through its gemspec constraint. Its Excon usage remains compatible with the 1.5 API, so the upper bound can safely move to the next major version.

## Impact

Applications can upgrade to Excon 1.5 without dependency conflicts from `simple_spark`. There are no runtime code changes.

## Validation

- full RSpec suite with Excon 1.5.0: 29 examples, 0 failures
- built the `simple_spark` gem successfully and verified its packaged Excon requirement is `>= 0.16.0, < 2.0`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line gemspec constraint change with no application code modified; existing Excon usage in the client is unchanged.
> 
> **Overview**
> **Dependency only:** the gemspec now declares `excon` as `>= 0.16.0, < 2.0` instead of `< 1.0`.
> 
> There are **no runtime or library code changes** in this PR—only the packaged dependency constraint. That unblocks Bundler from resolving Excon 1.x (e.g. 1.5) alongside `simple_spark` while still allowing existing Excon 0.x installs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7c970bb8afee88ad076667431f0705285ddd73e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->